### PR TITLE
fix cumulative queries

### DIFF
--- a/src/common/ormConnection.ts
+++ b/src/common/ormConnection.ts
@@ -34,10 +34,10 @@ import {
 } from "../models/";
 import { ENABLE_PG_SSL } from "./constants";
 
-createConnection({
+const connectionPromise: Promise<Connection> = createConnection({
     name: 'default',
     type: "postgres",
-    //synchronize: false, // call synchronize() explicitly when the app starts
+    // synchronize: true, // call synchronize() explicitly when the app starts
     extra: ENABLE_PG_SSL ? { ssl: { rejectUnauthorized: false } } : {},
     logging: ["error"],
     maxQueryExecutionTime: 1000,
@@ -76,5 +76,6 @@ createConnection({
 })
 
 export const getTypeORMConnection: () => Promise<Connection> = async () => {
+    await connectionPromise; // make sure promise is resolved to prevent race condition
     return getConnection('default');
 };

--- a/src/issue/issueDataService.ts
+++ b/src/issue/issueDataService.ts
@@ -45,7 +45,7 @@ export async function getRecentDailyIssues(
         SELECT extract(epoch from d.date) * 1000 as date, coalesce(SUM(ex.amount_btc::INTEGER), 0) AS sat
         FROM (SELECT (current_date - offs) AS date FROM generate_series(0, $1, 1) AS offs) d
         LEFT OUTER JOIN v_parachain_data_execute_issue AS ex LEFT OUTER JOIN v_parachain_data_request_issue AS req USING (issue_id)
-        ON d.date = ex.block_ts::date
+        ON d.date >= ex.block_ts::date
         GROUP BY 1
         ORDER BY 1 ASC`, [daysBack])).rows
     } catch (e) {

--- a/src/redeem/redeemDataService.ts
+++ b/src/redeem/redeemDataService.ts
@@ -61,9 +61,10 @@ export async function getRecentDailyRedeems(
         SELECT extract(epoch from d.date) * 1000 as date, coalesce(SUM(ex.amount_polka_btc::INTEGER), 0) AS sat
         FROM (SELECT (current_date - offs) AS date FROM generate_series(0, $1, 1) AS offs) d
         LEFT OUTER JOIN v_parachain_redeem_execute AS ex LEFT OUTER JOIN v_parachain_redeem_request AS req USING (redeem_id)
-        ON d.date = ex.block_ts::date
+        ON d.date >= ex.block_ts::date
         GROUP BY 1
-        ORDER BY 1 ASC`, [daysBack]))
+        ORDER BY 1 ASC
+            `, [daysBack]))
             .rows
             .map((row) => ({ date: row.date, sat: row.sat }));
     } catch (e) {

--- a/src/relayers/relayersDataService.ts
+++ b/src/relayers/relayersDataService.ts
@@ -22,11 +22,12 @@ export async function getRecentDailyRelayers(
         (
             SELECT COUNT(relayer_id) AS reg
             FROM v_parachain_stakedrelayer_register
-            WHERE block_ts::date = d.date AND maturity::Integer < (SELECT max(block_number) as block_number FROM parachain_events)
+            WHERE block_ts::date <= d.date AND maturity::Integer < (SELECT max(block_number) as block_number FROM parachain_events)
         ) as regs,
-        (SELECT COUNT(relayer_id) AS dereg FROM v_parachain_stakedrelayer_deregister WHERE block_ts::date = d.date) as deregs
+        (SELECT COUNT(relayer_id) AS dereg FROM v_parachain_stakedrelayer_deregister WHERE block_ts::date <= d.date) as deregs
         FROM (SELECT (current_date - offs) AS date FROM generate_series(0, $1, 1) AS offs) d
-        ORDER BY 1 ASC`, [daysBack]))
+        ORDER BY 1 ASC
+            `, [daysBack]))
             .rows
             .map((row) => ({ date: row.date, count: Math.max(row.regs - row.deregs, 0) }));
     } catch (e) {

--- a/src/vaults/vaultDataService.ts
+++ b/src/vaults/vaultDataService.ts
@@ -22,7 +22,7 @@ export async function getRecentDailyVaults(
         SELECT extract(epoch from d.date) * 1000 as date, count(v.vault_id) as value
         FROM (SELECT (current_date - offs) AS date FROM generate_series(0, $1, 1) AS offs) d
         LEFT OUTER JOIN v_parachain_vault_registration v
-        ON d.date = v.block_ts::date
+        ON d.date >= v.block_ts::date
         GROUP BY 1
         ORDER BY 1 ASC`, [daysBack]))
             .rows


### PR DESCRIPTION
Changed the per-day cumulative endpoints to return cumulative data for each datapoint rather than per-day results.

Note: this isn't well tested, since the issue only shows up with multiple days of data which I lack on my local chain. If there is a way to confirm it works as expected using a realistic dataset, that would be great.