### PR TITLE
Added parameter to vaults and relayers query for `lifetime sla` cutoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@interlay/polkabtc-stats",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/relayers/relayersDataController.ts
+++ b/src/relayers/relayersDataController.ts
@@ -21,7 +21,9 @@ export class RelayersController extends Controller {
     }
 
     @Get("")
-    public async getRelayers(): Promise<RelayerData[]> {
-        return getAllRelayers();
+    public async getRelayers(
+        @Query() slaSince: number
+    ): Promise<RelayerData[]> {
+        return getAllRelayers(slaSince);
     }
 }

--- a/src/relayers/relayersDataController.ts
+++ b/src/relayers/relayersDataController.ts
@@ -20,6 +20,11 @@ export class RelayersController extends Controller {
         return getRelayersWithTrackRecord(minSla, minConsecutivePeriod);
     }
 
+    /**
+     * Retrieves a full list of relayers, along with the unbounded sum SLA scores
+     * after a given cutoff.
+     * @param slaSince A UNIX timestamp starting from which the SLA score will be summed.
+     **/
     @Get("")
     public async getRelayers(
         @Query() slaSince: number

--- a/src/vaults/vaultDataController.ts
+++ b/src/vaults/vaultDataController.ts
@@ -33,7 +33,9 @@ export class VaultsController extends Controller {
     }
 
     @Get("")
-    public async getVaults(): Promise<VaultData[]> {
-        return getAllVaults();
+    public async getVaults(
+        @Query() slaSince: number
+    ): Promise<VaultData[]> {
+        return getAllVaults(slaSince);
     }
 }

--- a/src/vaults/vaultDataController.ts
+++ b/src/vaults/vaultDataController.ts
@@ -32,6 +32,11 @@ export class VaultsController extends Controller {
         return getVaultsWithTrackRecord(minSla, minConsecutivePeriod);
     }
 
+    /**
+     * Retrieves a full list of vaults, along with the unbounded sum SLA scores
+     * after a given cutoff.
+     * @param slaSince A UNIX timestamp starting from which the SLA score will be summed.
+     **/
     @Get("")
     public async getVaults(
         @Query() slaSince: number


### PR DESCRIPTION
This will probably be refactored when more general searching is implemented, but is sufficient to get the challenge leaderboards working.