### PR TITLE
Paged leaderboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@interlay/polkabtc-stats",
-    "version": "0.1.21",
+    "version": "0.2.0",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/common/columnTypes.ts
+++ b/src/common/columnTypes.ts
@@ -42,4 +42,29 @@ export type StatusUpdateColumns =
 
 export type BlockColumns = "height" | "hash" | "relay_ts";
 
-export type Colmuns = IssueColumns | RedeemColumns | StatusUpdateColumns | BlockColumns;
+export type VaultColumns =
+    | "vault_id"
+    | "block_number"
+    | "collateral"
+    | "request_issue_count"
+    | "execute_issue_count"
+    | "request_redeem_count"
+    | "execute_redeem_count"
+    | "cancel_redeem_count"
+    | "lifetime_sla_change";
+export type RelayerColumns =
+    | "relayer_id"
+    | "block_number"
+    | "stake"
+    | "deregistered"
+    | "slashed"
+    | "bonded"
+    | "lifetime_sla_change";
+
+export type Colmuns =
+    | IssueColumns
+    | RedeemColumns
+    | StatusUpdateColumns
+    | BlockColumns
+    | VaultColumns
+    | RelayerColumns;

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -29,7 +29,10 @@ export function filtersToWhere<C extends Colmuns>(filters: Filter<C>[]) {
             (cond, filter) =>
                 cond +
                 `${format.ident(filter.column)} ${
-                    filter.comparison || "="
+                    filter.comparison &&
+                    ["=", "<", ">"].includes(filter.comparison)
+                        ? filter.comparison
+                        : "="
                 } ${format.literal(filter.value)} AND `,
             "WHERE "
         )

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -19,6 +19,7 @@ export type BtcNetworkName = "mainnet" | "testnet" | "regtest";
 export type Filter<C extends Colmuns> = {
     column: C;
     value: string;
+    comparison?: "=" | "<" | ">"; // defaults to '='
 };
 
 export function filtersToWhere<C extends Colmuns>(filters: Filter<C>[]) {
@@ -27,9 +28,9 @@ export function filtersToWhere<C extends Colmuns>(filters: Filter<C>[]) {
         .reduce(
             (cond, filter) =>
                 cond +
-                `${format.ident(filter.column)} = ${format.literal(
-                    filter.value
-                )} AND `,
+                `${format.ident(filter.column)} ${
+                    filter.comparison || "="
+                } ${format.literal(filter.value)} AND `,
             "WHERE "
         )
         .slice(0, -5);
@@ -58,12 +59,12 @@ export function btcAddressToString(
         paymentType === "P2WPKHv0"
             ? payments.p2wpkh
             : paymentType === "P2PKH"
-                ? payments.p2pkh
-                : paymentType === "P2SH"
-                    ? payments.p2sh
-                    : () => {
-                        throw new Error("Invalid address type");
-                    };
+            ? payments.p2pkh
+            : paymentType === "P2SH"
+            ? payments.p2sh
+            : () => {
+                  throw new Error("Invalid address type");
+              };
     return (
         payment({
             hash,
@@ -72,9 +73,7 @@ export function btcAddressToString(
     );
 }
 
-export function hexStringFixedPointToBig(
-    fixedPoint: string
-): Big {
+export function hexStringFixedPointToBig(fixedPoint: string): Big {
     const typeRegistry = new TypeRegistry();
     const val = typeRegistry.createType("FixedI128", fixedPoint);
     return new Big(decodeFixedPointType(val as SignedFixedPoint));

--- a/src/models/VParachainStakedrelayerSlaUpdate.ts
+++ b/src/models/VParachainStakedrelayerSlaUpdate.ts
@@ -2,19 +2,19 @@ import { ViewEntity, ViewColumn } from "typeorm";
 
 @ViewEntity({
     expression: `
-        SELECT (v_parachain_data.event_data ->> 0) AS relayer_id,
-        (v_parachain_data.event_data ->> 1) AS new_sla,
-        (v_parachain_data.event_data ->> 2) AS delta,
-        v_parachain_data.block_ts
+        SELECT v_parachain_data.event_data ->> 0 AS relayer_id,
+            coalesce((v_parachain_data.event_data ->> 3)::numeric,0) AS new_sla,
+            coalesce((v_parachain_data.event_data ->> 4)::numeric,0) AS delta,
+            v_parachain_data.block_ts
         FROM v_parachain_data
-        WHERE ((v_parachain_data.section = 'sla'::text) AND (v_parachain_data.method = 'UpdateRelayerSLA'::text));
+        WHERE v_parachain_data.section = 'sla'::text AND v_parachain_data.method = 'UpdateRelayerSLA'::text;
     `,
     name: "v_parachain_stakedrelayer_sla_update",
 })
 export class VParachainStakedrelayerSlaUpdate {
 
     @ViewColumn()
-    vault_id: string;
+    relayer_id: string;
 
     @ViewColumn()
     new_sla: string;

--- a/src/models/VParachainVaultSlaUpdate.ts
+++ b/src/models/VParachainVaultSlaUpdate.ts
@@ -2,12 +2,12 @@ import { ViewEntity, ViewColumn } from "typeorm";
 
 @ViewEntity({
     expression: `
-        SELECT (v_parachain_data.event_data ->> 0) AS vault_id,
-        (v_parachain_data.event_data ->> 1) AS new_sla,
-        (v_parachain_data.event_data ->> 2) AS delta,
-        v_parachain_data.block_ts
+        SELECT v_parachain_data.event_data ->> 0 AS vault_id,
+            coalesce((v_parachain_data.event_data ->> 3)::numeric,0) AS new_sla,
+            coalesce((v_parachain_data.event_data ->> 4)::numeric,0) AS delta,
+            v_parachain_data.block_ts
         FROM v_parachain_data
-        WHERE ((v_parachain_data.section = 'sla'::text) AND (v_parachain_data.method = 'UpdateVaultSLA'::text));
+        WHERE v_parachain_data.section = 'sla'::text AND v_parachain_data.method = 'UpdateVaultSLA'::text;
     `,
     name: "v_parachain_vault_sla_update",
 })

--- a/src/oracle/oracleDataController.ts
+++ b/src/oracle/oracleDataController.ts
@@ -24,12 +24,18 @@ export class OracleDataController extends Controller {
         };
     })();
 
+    /**
+     * Retrieves the last update from each of the oracles in the system.
+     **/
     @Get("/submissions")
     public async getLatestSubmissionForEachOracle(): Promise<OracleStatus[]> {
         const oracleCache = await this.cachedOracleData;
         return getLatestSubmissionForEachOracle(oracleCache.onlineTimeout, oracleCache.feed, oracleCache.namesMap);
     }
 
+    /**
+     * Retrieves the latest update (from any oracle).
+     **/
     @Get("/latest")
     public async getLatestSubmission(): Promise<OracleStatus> {
         const oracleCache = await this.cachedOracleData;

--- a/src/parachain/parachainDataController.ts
+++ b/src/parachain/parachainDataController.ts
@@ -10,6 +10,9 @@ import { ParachainStatusUpdate } from "./parachainModels";
 @Tags("stats")
 @Route("statusUpdates")
 export class ParachainController extends Controller {
+    /**
+     * Retrieves a paged list of parachain status updates.
+     **/
     @Get("")
     public async getParachainStatusUpdates(
         @Query() page = 0,
@@ -31,6 +34,9 @@ export class ParachainController extends Controller {
         return getPagedStatusUpdates(page, perPage, sortBy, sortAsc, filters);
     }
 
+    /**
+     * Gets the total count of status updates submitted (regardless of voting status).
+     **/
     @Get("total")
     public async getTotalParachainStatusUpdates(): Promise<string> {
         return getTotalStatusUpdates();

--- a/src/redeem/redeemDataController.ts
+++ b/src/redeem/redeemDataController.ts
@@ -14,21 +14,34 @@ import { RedeemColumns } from "../common/columnTypes";
 @Tags("stats")
 @Route("redeems")
 export class RedeemsController extends Controller {
+    /**
+     * Returns the total count of successfully executed redeems.
+     **/
     @Get("totalSuccessful")
     public async getTotalSuccessfulRedeems(): Promise<string> {
         return getTotalSuccessfulRedeems();
     }
 
+    /**
+     * Returns the total count of redeem requests (regardless of execution).
+     **/
     @Get("total")
     public async getTotalRedeems(): Promise<string> {
         return getTotalRedeems();
     }
 
+    /**
+     * Retrieves the total value of polkaBTC successfully redeemed (all time).
+     **/
     @Get("totalAmount")
     public async getTotalRedeemedAmount(): Promise<string> {
         return getTotalAmount();
     }
 
+    /**
+     * Gets the total amount redeemed before midnight for the last several days
+     * @param daysBack number of days (starting from the next midnight) to give datapoints for
+     **/
     @Get("recentDaily")
     public async getRecentDailyRedeems(
         @Query() daysBack = 5
@@ -47,6 +60,11 @@ export class RedeemsController extends Controller {
         return getPagedRedeems(page, perPage, sortBy, sortAsc, [], network);
     }
 
+    /**
+     * Retrieves a paged list of issue requests.
+     * @param network the BTC network used for redeem transactions; necessary to correctly
+     * decode vault addresses and transaction IDs.
+     **/
     @Post("")
     public async getFilteredRedeems(
         @Query() page = 0,

--- a/src/relayBlocks/blockController.ts
+++ b/src/relayBlocks/blockController.ts
@@ -6,6 +6,9 @@ import { BlockColumns } from "../common/columnTypes";
 @Tags("stats")
 @Route("blocks")
 export class CumulativeBlocksController extends Controller {
+    /**
+     * Retrieves a paged list of BTC blocks submitted to the relay.
+     **/
     @Get("")
     public async getBlocks(
         @Query() page = 0,
@@ -16,6 +19,9 @@ export class CumulativeBlocksController extends Controller {
         return getPagedBlocks(page, perPage, sortBy, sortAsc);
     }
 
+    /**
+     * Retrieves the total amount of blocks submitted to BTCRelay.
+     **/
     @Get("count")
     public async getTotalRelayedBlocksCount(): Promise<string> {
         return totalRelayedBlocks();

--- a/src/relayers/relayersDataController.ts
+++ b/src/relayers/relayersDataController.ts
@@ -1,10 +1,17 @@
-import { Controller, Get, Query, Route, Tags } from "tsoa";
+import { Body, Controller, Get, Post, Query, Route, Tags } from "tsoa";
+import {RelayerColumns} from "../common/columnTypes";
+import {Filter} from "../common/util";
 import { getAllRelayers, getRecentDailyRelayers, getRelayersWithTrackRecord } from "./relayersDataService";
 import { RelayerData, RelayerCountTimeData, RelayerSlaRanking } from "./relayersModel";
 
 @Tags("stats")
 @Route("relayers")
 export class RelayersController extends Controller {
+    /**
+     * Gets the total number of relayers registered at midnight for the last several days
+     * Does not take into account online status, only registration.
+     * @param daysBack number of days (starting from the next midnight) to give datapoints for
+     **/
     @Get("recentDailyCounts")
     public async getRecentDailyRelayerCounts(
         @Query() daysBack = 5
@@ -12,6 +19,11 @@ export class RelayersController extends Controller {
         return getRecentDailyRelayers(daysBack);
     }
 
+    /**
+     * Returns a list of relayers with a minimum SLA track record, as specified by the parameters.
+     * @param minSla the SLA theshold to consider
+     * @param minConsecutivePeriod the duration above which the relayer must have had SLA above minSLA (in miliseconds)
+     **/
     @Get("relayersWithTrackRecord")
     public async listRelayersWithTrackRecord(
         @Query() minSla = 0,
@@ -21,14 +33,30 @@ export class RelayersController extends Controller {
     }
 
     /**
-     * Retrieves a full list of relayers, along with the unbounded sum SLA scores
+     * Retrieves a paged list of relayers, along with the unbounded sum SLA scores
      * after a given cutoff.
      * @param slaSince A UNIX timestamp starting from which the SLA score will be summed.
      **/
     @Get("")
     public async getRelayers(
+        @Query() page = 0,
+        @Query() perPage = 20,
+        @Query() sortBy: RelayerColumns = "block_number",
+        @Query() sortAsc = false,
         @Query() slaSince: number
     ): Promise<RelayerData[]> {
-        return getAllRelayers(slaSince);
+        return getAllRelayers(page, perPage, sortBy, sortAsc, [], slaSince);
+    }
+
+    @Post("")
+    public async getFilteredRelayers(
+        @Query() page = 0,
+        @Query() perPage = 20,
+        @Query() sortBy: RelayerColumns = "block_number",
+        @Query() sortAsc = false,
+        @Body() filters: Filter<RelayerColumns>[] = [],
+        @Query() slaSince: number
+    ): Promise<RelayerData[]> {
+        return getAllRelayers(page, perPage, sortBy, sortAsc, filters, slaSince);
     }
 }


### PR DESCRIPTION
Adds the same paging as everywhere else to the leaderboard tables. (Breaking API changes, UI request to adapt is WIP.)
Also adds some doc comments to all the API endpoints.

The current `columnTypes` construction is rather inelegant, but I'm waiting until the task of unifying parachain+lib+stats types is undertaken. Once the types are settled, the explicit DB columns can be replaced by a mapping from struct properties to the SQL columns, allowing sorting/filtering by the struct properties in the API calls rather than having to check which column name to use.