### PR TITLE
fix(distinct): fixed failing queries due to inconsistencies

### DIFF
--- a/src/parachain/parachainDataService.ts
+++ b/src/parachain/parachainDataService.ts
@@ -147,8 +147,8 @@ export async function getPagedStatusUpdates(
                 suggest.btc_block_hash,
                 (SELECT COUNT(*) FROM v_parachain_status_vote WHERE approve = 'true' AND update_id = suggest.update_id GROUP BY update_id) AS yeas,
                 (SELECT COUNT(*) FROM v_parachain_status_vote WHERE approve = 'false' AND update_id = suggest.update_id GROUP BY update_id) AS nays,
-                coalesce((SELECT TRUE AS executed FROM "v_parachain_status_execute" WHERE update_id = suggest.update_id), FALSE) AS executed,
-                coalesce((SELECT TRUE AS rejected FROM "v_parachain_status_reject" WHERE update_id = suggest.update_id), FALSE) AS rejected,
+                coalesce((SELECT DISTINCT TRUE AS executed FROM "v_parachain_status_execute" WHERE update_id = suggest.update_id), FALSE) AS executed,
+                coalesce((SELECT DISTINCT TRUE AS rejected FROM "v_parachain_status_reject" WHERE update_id = suggest.update_id), FALSE) AS rejected,
                 FALSE AS forced
             FROM
                 "v_parachain_status_suggest" AS suggest

--- a/src/relayBlocks/blockService.ts
+++ b/src/relayBlocks/blockService.ts
@@ -11,7 +11,7 @@ export async function getPagedBlocks(
     sortAsc: boolean
 ): Promise<BtcBlock[]> {
     const res = await pool.query(`
-        SELECT DISTINCT ON (hash)
+        SELECT DISTINCT
             ("event_data" ->> 0)::INTEGER AS height, "event_data" ->> 1 AS "hash", "block_ts" AS "relay_ts"
         FROM "v_parachain_data"
         WHERE "section"='btcRelay'::text AND "method"='StoreMainChainHeader'::text


### PR DESCRIPTION
This removes the `DISTINCT ON (hash)` from the blocks query, but this will only arise due to an issue with inserting events (and never during normal operation).

The other issue happened because for some reason status update 39 on beta was executed twice, once at parachain height 83865 and once at 98248. The query can now handle this without failing.