### PR TITLE
fix(parachain): quickfix query failing on forced status updates

### DIFF
--- a/src/parachain/parachainDataService.ts
+++ b/src/parachain/parachainDataService.ts
@@ -181,7 +181,7 @@ export async function getPagedStatusUpdates(
             proposedStatus: row.new_status,
             addError: row.add_error,
             removeError: row.remove_error,
-            btc_block_hash: stripHexPrefix(row.btc_block_hash),
+            btc_block_hash: row.btc_block_hash? stripHexPrefix(row.btc_block_hash) : '',
             yeas: row.yeas,
             nays: row.nays,
             executed: row.executed ? true : false,


### PR DESCRIPTION
`stripHexPrefix` doesn't handle undefined values, which are passed when the update was a sudo forced update